### PR TITLE
Refactor dynamicCharts to load metadata

### DIFF
--- a/force-app/main/default/lwc/dynamicCharts/__tests__/dynamicCharts.shadow.test.js
+++ b/force-app/main/default/lwc/dynamicCharts/__tests__/dynamicCharts.shadow.test.js
@@ -1,5 +1,28 @@
 import { createElement } from "lwc";
 import DynamicCharts from "c/dynamicCharts";
+import { loadScript } from "lightning/platformResourceLoader";
+
+jest.mock("lightning/platformResourceLoader", () => ({
+  loadScript: jest.fn(() => Promise.resolve())
+}));
+
+global.ApexCharts = function () {
+  this.render = jest.fn();
+  this.updateOptions = jest.fn();
+};
+
+const mockResponse = {
+  pages: [
+    { id: "ClimbsByNation", charts: ["ClimbsByNation", "ClimbsByNationAO"] }
+  ],
+  chartSettings: {
+    ClimbsByNation: { effects: ["shadow"] }
+  }
+};
+
+global.fetch = jest.fn(() =>
+  Promise.resolve({ json: () => Promise.resolve(mockResponse) })
+);
 
 describe("c-dynamic-charts drop shadow", () => {
   afterEach(() => {
@@ -11,6 +34,7 @@ describe("c-dynamic-charts drop shadow", () => {
   it("adds dropShadow settings when effects include shadow", () => {
     const element = createElement("c-dynamic-charts", { is: DynamicCharts });
     document.body.appendChild(element);
+    element.chartSettings = { ClimbsByNation: { effects: ["shadow"] } };
     const options = { chart: {} };
     const updated = element.applySettings.call(
       element,

--- a/force-app/main/default/lwc/dynamicCharts/__tests__/dynamicCharts.test.js
+++ b/force-app/main/default/lwc/dynamicCharts/__tests__/dynamicCharts.test.js
@@ -3,6 +3,30 @@ import { createElement } from "lwc";
 import DynamicCharts from "c/dynamicCharts";
 import { loadScript } from "lightning/platformResourceLoader";
 
+jest.mock("lightning/platformResourceLoader", () => ({
+  loadScript: jest.fn(() => Promise.resolve())
+}));
+
+global.ApexCharts = function () {
+  this.render = jest.fn();
+  this.updateOptions = jest.fn();
+};
+
+const mockResponse = {
+  pages: [
+    { id: "ClimbsByNation", charts: ["ClimbsByNation", "ClimbsByNationAO"] },
+    { id: "CampsByPeak", charts: ["CampsByPeak", "CampsByPeakAO"] },
+    { id: "TimeByPeak", charts: ["TimeByPeak", "TimeByPeakAO"] }
+  ],
+  chartSettings: {
+    ClimbsByNation: { effects: ["shadow"] }
+  }
+};
+
+global.fetch = jest.fn(() =>
+  Promise.resolve({ json: () => Promise.resolve(mockResponse) })
+);
+
 const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0));
 
 describe("c-dynamic-charts", () => {
@@ -13,31 +37,37 @@ describe("c-dynamic-charts", () => {
     }
   });
 
-  it("renders chart container", () => {
+  it("renders chart container", async () => {
     const element = createElement("c-dynamic-charts", {
       is: DynamicCharts
     });
     document.body.appendChild(element);
+
+    await flushPromises();
 
     const chartDiv = element.shadowRoot.querySelector("div.ClimbsByNation");
     expect(chartDiv).not.toBeNull();
   });
 
-  it("renders second chart container", () => {
+  it("renders second chart container", async () => {
     const element = createElement("c-dynamic-charts", {
       is: DynamicCharts
     });
     document.body.appendChild(element);
+
+    await flushPromises();
 
     const chartDiv = element.shadowRoot.querySelector("div.ClimbsByNationAO");
     expect(chartDiv).not.toBeNull();
   });
 
-  it("renders box plot containers", () => {
+  it("renders box plot containers", async () => {
     const element = createElement("c-dynamic-charts", {
       is: DynamicCharts
     });
     document.body.appendChild(element);
+
+    await flushPromises();
 
     const chart3 = element.shadowRoot.querySelector("div.TimeByPeak");
     const chart4 = element.shadowRoot.querySelector("div.TimeByPeakAO");
@@ -49,11 +79,13 @@ describe("c-dynamic-charts", () => {
     expect(chart7).not.toBeNull();
   });
 
-  it("shows ClimbsByNation page by default", () => {
+  it("shows ClimbsByNation page by default", async () => {
     const element = createElement("c-dynamic-charts", {
       is: DynamicCharts
     });
     document.body.appendChild(element);
+
+    await flushPromises();
 
     const climbsPage = element.shadowRoot.querySelector(
       "div[data-page='ClimbsByNation']"
@@ -66,6 +98,8 @@ describe("c-dynamic-charts", () => {
       is: DynamicCharts
     });
     document.body.appendChild(element);
+
+    await flushPromises();
 
     const link = element.shadowRoot.querySelector("a[data-id='TimeByPeak']");
     link.click();
@@ -82,6 +116,8 @@ describe("c-dynamic-charts", () => {
       is: DynamicCharts
     });
     document.body.appendChild(element);
+
+    await flushPromises();
 
     const errorSpy = jest.spyOn(console, "error");
     await Promise.resolve();

--- a/force-app/main/default/lwc/dynamicCharts/dynamicCharts.html
+++ b/force-app/main/default/lwc/dynamicCharts/dynamicCharts.html
@@ -65,87 +65,32 @@
   <lightning-layout>
     <lightning-layout-item size="2">
       <ul class="slds-list_dotted">
-        <li>
-          <a
-            href="javascript:void(0);"
-            data-id="ClimbsByNation"
-            onclick={handleNavClick}
-            >ClimbsByNation</a
-          >
-        </li>
-        <li>
-          <a
-            href="javascript:void(0);"
-            data-id="CampsByPeak"
-            onclick={handleNavClick}
-            >CampsByPeak</a
-          >
-        </li>
-        <li>
-          <a
-            href="javascript:void(0);"
-            data-id="TimeByPeak"
-            onclick={handleNavClick}
-            >TimeByPeak</a
-          >
-        </li>
+        <template for:each={pagesWithState} for:item="page">
+          <li key={page.id}>
+            <a
+              href="javascript:void(0);"
+              data-id={page.id}
+              onclick={handleNavClick}
+              >{page.id}</a
+            >
+          </li>
+        </template>
       </ul>
     </lightning-layout-item>
     <lightning-layout-item size="10">
-      <div class={climbsPageClass} data-page="ClimbsByNation">
-        <lightning-card title="Chart Series" icon-name="custom:custom1">
-          <lightning-layout>
-            <lightning-layout-item size="6">
-              <div
-                class="ClimbsByNation slds-var-m-around_medium"
-                lwc:dom="manual"
-              ></div>
-            </lightning-layout-item>
-            <lightning-layout-item size="6">
-              <div
-                class="ClimbsByNationAO slds-var-m-around_medium"
-                lwc:dom="manual"
-              ></div>
-            </lightning-layout-item>
-          </lightning-layout>
-        </lightning-card>
-      </div>
-      <div class={campsPageClass} data-page="CampsByPeak">
-        <lightning-card title="Chart Series" icon-name="custom:custom1">
-          <lightning-layout>
-            <lightning-layout-item size="6">
-              <div
-                class="CampsByPeak slds-var-m-around_medium"
-                lwc:dom="manual"
-              ></div>
-            </lightning-layout-item>
-            <lightning-layout-item size="6">
-              <div
-                class="CampsByPeakAO slds-var-m-around_medium"
-                lwc:dom="manual"
-              ></div>
-            </lightning-layout-item>
-          </lightning-layout>
-        </lightning-card>
-      </div>
-      <div class={timePageClass} data-page="TimeByPeak">
-        <lightning-card title="Box Plot Series" icon-name="custom:custom2">
-          <lightning-layout>
-            <lightning-layout-item size="6">
-              <div
-                class="TimeByPeak slds-var-m-around_medium"
-                lwc:dom="manual"
-              ></div>
-            </lightning-layout-item>
-            <lightning-layout-item size="6">
-              <div
-                class="TimeByPeakAO slds-var-m-around_medium"
-                lwc:dom="manual"
-              ></div>
-            </lightning-layout-item>
-          </lightning-layout>
-        </lightning-card>
-      </div>
+      <template for:each={pagesWithState} for:item="page">
+        <div key={page.id} data-page={page.id} class={page.cssClass}>
+          <lightning-card title="Chart Series" icon-name={page.iconName}>
+            <lightning-layout>
+              <template for:each={page.chartList} for:item="chart">
+                <lightning-layout-item size="6" key={chart.id}>
+                  <div class={chart.cssClass} lwc:dom="manual"></div>
+                </lightning-layout-item>
+              </template>
+            </lightning-layout>
+          </lightning-card>
+        </div>
+      </template>
     </lightning-layout-item>
   </lightning-layout>
 </template>

--- a/force-app/main/default/staticresources/chartMetadata.json
+++ b/force-app/main/default/staticresources/chartMetadata.json
@@ -1,0 +1,45 @@
+{
+  "pages": [
+    {
+      "id": "ClimbsByNation",
+      "charts": ["ClimbsByNation", "ClimbsByNationAO"]
+    },
+    {
+      "id": "CampsByPeak",
+      "charts": ["CampsByPeak", "CampsByPeakAO"]
+    },
+    {
+      "id": "TimeByPeak",
+      "charts": ["TimeByPeak", "TimeByPeakAO"]
+    }
+  ],
+  "chartSettings": {
+    "ClimbsByNation": {
+      "dashboard": "CR_02",
+      "title": "Top 20 Climbs by Nation",
+      "fieldMappings": { "nation": "Nation", "Climbs": "Climbs" },
+      "colors": ["#002060"],
+      "effects": ["shadow"]
+    },
+    "TimeByPeak": {
+      "dashboard": "CR_02",
+      "title": "Days per Peak by Top 20 Climbs",
+      "fieldMappings": {
+        "peakid": "Peak ID",
+        "A": "Min",
+        "B": "Q1",
+        "C": "Q3",
+        "D": "Max"
+      },
+      "colors": ["#97C1DA", "#002060"],
+      "effects": ["shadow"]
+    },
+    "CampsByPeak": {
+      "dashboard": "CR_02",
+      "title": "Average Number of Camps per Peak",
+      "fieldMappings": { "peakid": "Peak ID", "A": "Average Camps" },
+      "colors": ["#175F68"],
+      "effects": ["shadow"]
+    }
+  }
+}

--- a/force-app/main/default/staticresources/chartMetadata.resource-meta.xml
+++ b/force-app/main/default/staticresources/chartMetadata.resource-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StaticResource xmlns="http://soap.sforce.com/2006/04/metadata">
+    <cacheControl>Private</cacheControl>
+    <contentType>application/json</contentType>
+</StaticResource>


### PR DESCRIPTION
## Summary
- load chart metadata from a static resource
- generate navigation and chart containers dynamically
- update Jest tests for the new architecture

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851eed89f2c8327b984e6857cc06688